### PR TITLE
Fix typo in Projects page (Pivotal)

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -16,7 +16,7 @@ layout: default
 
       <p><strong/>FreeSWITCH</strong><br>  (RTP media workhorse <strong/>used by Kazoo</strong>) <br>by primary authors <a href="https://freeswitch.org/" target="_new">FreeSWITCH Solutions Inc.</a> <br>
 
-      <p><strong/>RabbitMQ</strong><br>  (Messaging and Event server <strong/>used by Kazoo</strong>) <br>by primary author <a href="https://www.rabbitmq.com/" target="_new">Pivolat</a> <br>
+      <p><strong/>RabbitMQ</strong><br>  (Messaging and Event server <strong/>used by Kazoo</strong>) <br>by primary author <a href="https://www.rabbitmq.com/" target="_new">Pivotal</a> <br>
         <a class="github-button" href="https://github.com/rabbitmq/rabbitmq-server" aria-label="RabbitMQ on GitHub" target="_new">Check-out RabbitMQ on Github</a></p>
 
       <p><strong/>CouchDB</strong><br>  (NoSQL Databse <strong/>used by Kazoo</strong>)  <br>by primary sponsor <a href="http://couchdb.apache.org/" target="_new">Apache Software Foundation</a> <br>


### PR DESCRIPTION
typo with [pivotal](https://pivotal.io/) instead of *pivolat*